### PR TITLE
build(deps): unblock restore, align EF Core to 10.0.9

### DIFF
--- a/src/Daab.Web/Program.cs
+++ b/src/Daab.Web/Program.cs
@@ -43,10 +43,12 @@ var app = builder.Build();
 
 app.UseExceptionHandler();
 app.UseCors();
-app.UseForwardedHeaders(new ForwardedHeadersOptions
-{
-    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
-});
+app.UseForwardedHeaders(
+    new ForwardedHeadersOptions
+    {
+        ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto,
+    }
+);
 app.UseImageSharp();
 app.UseStaticFiles();
 app.UseAuthModule();

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,6 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- GHSA-2m69-gcr7-jv3q: SQLite vuln in transitive SQLitePCLRaw.lib.e_sqlite3 2.1.11
+         (pulled by Microsoft.EntityFrameworkCore.Sqlite). No patched 2.x release; SQLitePCLRaw v3
+         dropped this package but EF Core 10 is not yet on v3. Re-evaluate when EF ships a fixed native. -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -18,9 +18,9 @@
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageVersion Include="SixLabors.ImageSharp.Web.Providers.AWS" Version="3.2.0" />
     <PackageVersion Include="Ulid" Version="1.4.1" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2" />


### PR DESCRIPTION
Suppress NuGet audit advisory GHSA-2m69-gcr7-jv3q for the transitive SQLitePCLRaw.lib.e_sqlite3 2.1.11 SQLite vulnerability. No patched 2.x exists; EF Core 10 is not yet on SQLitePCLRaw v3, which drops the affected package. Suppression is scoped to this single advisory so future vulns still fail the build. Revisit when EF ships a fixed native bundle.

Align Microsoft.EntityFrameworkCore and .Design 10.0.2 -> 10.0.9 to match .Sqlite 10.0.9 and clear the NU1605 downgrade error.

Refs https://github.com/advisories/GHSA-2m69-gcr7-jv3q